### PR TITLE
Add a specific action to install Telepresence

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,14 +21,19 @@ inputs:
     description: Only intercept traffic that matches this "HTTP2_HEADER=REGEXP" specifier
     required: false
     default: "x-telepresence-intercept-id=service-intercepted"
+  version:
+    description: The version  of Telepresence to use
+    required: false
+    default: latest
 runs:
   using: "composite"
   steps:
+    - name: Checkout local
+      uses: actions/checkout@v3
     - name: Install Telepresence
-      shell: bash
-      run: |
-        sudo curl -fL https://app.getambassador.io/download/tel2/linux/amd64/latest/telepresence -o /usr/local/bin/telepresence
-        sudo chmod a+x /usr/local/bin/telepresence
+      uses: ./install/
+      with:
+        version: ${{ inputs.version }}
     - name: Create kubeconfig file
       shell: bash
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -1,0 +1,15 @@
+name: 'Install Telepresence'
+description: 'Install a specific version of Telepresence'
+inputs:
+  version:
+    description: Version of Telepresence to install. The latest version is selected as default.
+    required: false
+    default: latest
+runs:
+  using: "composite"
+  steps:
+    - name: Install Telepresence
+      shell: bash
+      run: |
+        sudo curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${{inputs.version}}/telepresence -o /usr/local/bin/telepresence
+        sudo chmod a+x /usr/local/bin/telepresence


### PR DESCRIPTION
Before this PR we install Telepresence in the main action using the latest version. With this PR, the user is able to only install Telepresence with a specific version. The version parameter is not required, if the version is not specified, the latest version will be installed.