### PR TITLE
add -ur parameters

### DIFF
--- a/connect/disconnect.js
+++ b/connect/disconnect.js
@@ -1,9 +1,9 @@
 const core = require('@actions/core')
 const exec = require('@actions/exec');
 
-const telepresenceDisconnect = async function(){
+const telepresenceDisconnect = async function () {
     try {
-        await exec.exec('telepresence', ['quit']);
+        await exec.exec('telepresence', ['quit', '-ur']);
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
Before this PR the disconnect action executes the `quit` command without any parameter. We think this could be why the traffic manager stops working after some hours. This PR adds the parameter `-ur` to secure removing the root and user daemons.