### PR TITLE
Add support for the Telepresence client configuration file

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -2,7 +2,12 @@
 
 The telepresence connect action allows users to perform a `telepresence connect` command. It requires a `$KUBECONFIG` env var to point to a valid Kubernetes configuration file that contains information to connect to a remote cluster or a config file in `$HOME/.kube` as that's how `kubectl` searches for the information it needs to choose a cluster and communicate with the API server of a cluster. See [Organizing cluster access using kubeconfig files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 
-It's a good practice for users to store their KUBECONFIG yaml files as a Github Actions secret so that the contents are encrypted and masked out in the workflow's logs.
+It's a good practice for users to store their KUBECONFIG yaml file as a Github Actions secret so that the contents are encrypted and masked out in the workflow's logs.
+
+## Inputs
+| name | required | default value | description |
+| ----- | -------- | ----- | ----- |
+| telepresence_config_file | no  | | Path to the file that contains Telepresence client configuration values. See [this page](https://www.getambassador.io/docs/telepresence/latest/reference/config/) for more information. |
 
 ## Post action
 

--- a/connect/action.yaml
+++ b/connect/action.yaml
@@ -1,5 +1,9 @@
 name: 'Telepresence Connect'
 description: 'Telepresence connects to a remote cluster'
+inputs:
+  telepresence_config_file:
+    description: Path to the Telepresence client configuration values file
+    required: false
 runs:
   using: 'node16'
   main: 'connect.js'

--- a/connect/connect.js
+++ b/connect/connect.js
@@ -6,6 +6,15 @@ const telepresenceConnect = async function(){
     const isConfigured = await configure.getConfiguration();
     if(!isConfigured)
         return;
+
+    // Create telepresence configuration file
+    try {
+        await configure.createClientConfigFile(core.getInput('telepresence_config_file'));
+    } catch(err) {
+        core.setFailed(err);
+        return;
+    }
+
     try {
         await exec.exec('telepresence', ['connect']);
         core.saveState("telepresence_connected", true)

--- a/src/configure/index.js
+++ b/src/configure/index.js
@@ -1,4 +1,5 @@
 const core = require('@actions/core');
+const exec = require('@actions/exec');
 const io = require('@actions/io');
 const cache = require('@actions/cache');
 
@@ -31,9 +32,24 @@ exports.getConfiguration = async () => {
     return true;
 };
 
+/**
+ * Copies the given client configuration file to the user's Telepresence configuration directory
+ * @param telepresence_config_file the path to the Telepresence client configuration file
+ */
+exports.createClientConfigFile = async function(telepresence_config_file) {
+    if (!telepresence_config_file) {
+        return;
+    }
+    if (!telepresence_config_file.endsWith('.yaml')  && !telepresence_config_file.endsWith('.yml')) {
+        throw new Error('client_values_file values file must be a yaml file.');
+    }
+
+    const telepresenceConfigDir = this.getTelepresenceConfigPath();
+    await io.mkdirP(telepresenceConfigDir);
+    await exec.exec('cp', [telepresence_config_file, telepresenceConfigDir + '/config.yml']);
+}
+
 exports.TELEPRESENCE_ID_STATE = 'telepresence-id-state';
 exports.TELEPRESENCE_ID_SAVES = 'telepresence-saves';
 exports.TELEPRESENCE_ID_SAVED = 'telepresence-saved';
 exports.TELEPRESENCE_CACHE_KEY = 'telepresence_cache_key';
-
-


### PR DESCRIPTION
## Summary

Adds a new input param to the `connect` action to provide a Telepresence client configuration file that will be copied to the TP config directory in the runner so that the daemon uses it when stablishing connections to the remote cluster.

See:
- `connect/README.md`
- `connect/action.yaml`