### PR TITLE
Add support for yaml configuration

### DIFF
--- a/src/configure/index.js
+++ b/src/configure/index.js
@@ -1,6 +1,22 @@
 const core = require('@actions/core');
 const io = require('@actions/io');
 const cache = require('@actions/cache');
+const fs = require('fs');
+
+exports.fileExists = async function (filePath) {
+    try {
+        const stats = await fs.promises.stat(filePath);
+        if (!stats.isFile()) {
+            throw new Error('client_values_file must be a file.');
+        }
+        return true;
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            return false;
+        }
+        throw err;
+    }
+};
 
 exports.getTelepresenceConfigPath = () => {
     switch (process.platform) {
@@ -15,15 +31,17 @@ exports.getTelepresenceConfigPath = () => {
 };
 
 exports.getConfiguration = async () => {
+    const telepresenceCacheKey = process.env.TELEPRESENCE_CACHE_KEY;
+    if (!telepresenceCacheKey)
+        return false;
     const path = this.getTelepresenceConfigPath();
     try {
         await io.mkdirP(path);
-        const cacheid = await cache.restoreCache([path], this.TELEPRESENCE_CACHE_KEY,)
-        if (!cacheid){
+        const cacheid = await cache.restoreCache([path], telepresenceCacheKey);
+        if (!cacheid) {
             core.setFailed('Unable to find a telepresence install id stored');
             return false;
         }
-
     } catch (error) {
         core.setFailed(error);
         return false;
@@ -31,9 +49,42 @@ exports.getConfiguration = async () => {
     return true;
 };
 
+/**
+ * Copies the given client configuration file to the user's Telepresence configuration directory
+ */
+exports.createClientConfigFile = async function () {
+    let fileExists = false;
+    try {
+        fileExists = await this.fileExists(this.TELEPRESENCE_CONFIG_FILE_PATH);
+    } catch (err) {
+        core.warning('Error accessing telepresence config file. ' + err);
+        return;
+    }
+    if (!fileExists) {
+        return;
+    }
+
+    const telepresenceConfigDir = this.getTelepresenceConfigPath();
+    await exec.exec('cp', [this.TELEPRESENCE_CONFIG_FILE_PATH, telepresenceConfigDir + '/config.yml']);
+}
+
+exports.checksumConfigFile = function (algorithm) {
+    const filePath = process.env.GITHUB_WORKSPACE + this.TELEPRESENCE_CONFIG_FILE_PATH;
+    return new Promise(function (resolve, reject) {
+        let crypto = require('crypto');
+
+        let hash = crypto.createHash(algorithm).setEncoding('hex');
+        fs.createReadStream(filePath)
+            .once('error', reject)
+            .pipe(hash)
+            .once('finish', function () {
+                resolve(hash.read());
+            });
+    });
+}
+
 exports.TELEPRESENCE_ID_STATE = 'telepresence-id-state';
 exports.TELEPRESENCE_ID_SAVES = 'telepresence-saves';
 exports.TELEPRESENCE_ID_SAVED = 'telepresence-saved';
-exports.TELEPRESENCE_CACHE_KEY = 'telepresence_cache_key';
-
+exports.TELEPRESENCE_CONFIG_FILE_PATH = '/.github/telepresence-config/config.yml'
 


### PR DESCRIPTION
This PR adds support to save the configuration file on the user repository and use it during the workflow execution.

The user should save the configuration file in the path `.github/telepresence-config/config.yml`. If the user doesn't add a configuration file, the workflow is able to run successfully.

Each time the user requires to change a value on the file, the user should run the configure workflow in the main branch and update the active branch to grab all the changes.