### PR TITLE
Add GITHUB_ACTION_REF to inputActionVersion

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -5,10 +5,6 @@ inputs:
     description: Version of Telepresence to Install
     required: false
     default: latest
-  actionVersion:
-    description: Placeholder input that holds the Telepresence github actions version. Do not use.
-    required: false
-    default: ${{ github.action_ref }}
 runs:
   using: 'node16'
   pre: 'pre-install.js'

--- a/install/pre-install.js
+++ b/install/pre-install.js
@@ -2,7 +2,7 @@ const exec = require('@actions/exec')
 
 //set version by removing the v from vX.X.X, if it follows the format. if not, just return 0.0.0 
 const semVerRegex = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
-const inputActionVersion = process.env.INPUT_ACTIONVERSION
+const inputActionVersion = process.env.GITHUB_ACTION_REF
 const actionVersion = inputActionVersion && semVerRegex.test(inputActionVersion) ? inputActionVersion.substring(1) : '0.0.0'
 
 exec.exec('/bin/bash -c', ['echo TELEPRESENCE_REPORT_GITHUB_ACTIONS_INTEGRATION=true >> $GITHUB_ENV'])


### PR DESCRIPTION
Add GITHUB_ACTION_REF to inputActionVersion so we don't rely on the input of the action_ref on the action.yaml file